### PR TITLE
Add missing input parameters to action.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ payload if the action was triggered by a deployment.
 - `namespace`: Kubernetes namespace name. (required)
 - `chart`: Helm chart path. If set to "app" this will use the built in helm
   chart found in this repository. (required)
-- `chart_version`: The version of the helm chart you want to deploy (distinct from app version)
+- `chart-version`: The version of the helm chart you want to deploy (distinct from app version)
 - `values`: Helm chart values, expected to be a YAML or JSON string.
 - `track`: Track for the deployment. If the track is not "stable" it activates
   the canary workflow described below.

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,24 @@ inputs:
   version:
     description: Version of the app, usually commit sha works here.
     required: false
+  chart-version:
+    description: The version of the helm chart you want to deploy (distinct from app version)
+    required: false
+  track:
+    description: Track for the deployment. If the track is not "stable" it activates the canary workflow described in the docs.
+    required: false
+  repo:
+    description: Helm chart repository to be added.
+    required: false
+  repo-alias:
+    description: Helm repository alias that will be used.
+    required: false
+  repo-username:
+    description: Helm repository username if authentication is needed.
+    required: false
+  repo-password:
+    description: Helm repository password if authentication is needed.
+    required: false
 runs:
   using: docker
   image: Dockerfile


### PR DESCRIPTION
When using those parameters that are not in `action.yml` github keeps showing warning. This pr solves this warning.

Warning:
```
Unexpected input(s) 'chart-version', 'track', 'repo', 'repo-alias', 'repo-username', 'repo-password', valid inputs are ['entryPoint', 'args', 'release', 'namespace', 'chart', 'values', 'task', 'dry-run', 'atomic', 'helm', 'token', 'value-files', 'secrets', 'version']
```