### PR TITLE
Update Dockerfile to use 3.10 in PYTHONPATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add --no-cache ca-certificates \
     # Init version 2 helm:
     helm init --client-only
 
-ENV PYTHONPATH "/usr/lib/python3.8/site-packages/"
+ENV PYTHONPATH "/usr/lib/python3.10/site-packages/"
 
 COPY . /usr/src/
 ENTRYPOINT ["node", "/usr/src/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM alpine:3
+FROM alpine:3.16.0
 
 ENV BASE_URL="https://get.helm.sh"
 
 ENV HELM_2_FILE="helm-v2.17.0-linux-amd64.tar.gz"
 ENV HELM_3_FILE="helm-v3.8.1-linux-amd64.tar.gz"
+
+
+ENV PYTHONPATH "/usr/lib/python3.11/site-packages/"
 
 RUN apk add --no-cache ca-certificates \
     --repository http://dl-3.alpinelinux.org/alpine/edge/community/ \
@@ -21,7 +24,6 @@ RUN apk add --no-cache ca-certificates \
     # Init version 2 helm:
     helm init --client-only
 
-ENV PYTHONPATH "/usr/lib/python3.10/site-packages/"
 
 COPY . /usr/src/
 ENTRYPOINT ["node", "/usr/src/index.js"]


### PR DESCRIPTION
[UPDATE]

I found the same issue agan as the Dockerfile had only the major version in the FROM image.

I have pinned the alpine image and change the PYTHONEVN path accordingly

====

Latest Alpine release has upgraded the python version to 3.10 (See: https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.16.0#Python_upgraded_to_3.10)

As the PYTHONPATH is harcoded, the Dockerfile needs to be updated accordingly.

This fixes the issue of `aws cli` not working:

```
Traceback (most recent call last):
  File "/usr/bin/aws", line 19, in <module>
    import awscli.clidriver
ModuleNotFoundError: No module named 'awscli'
```

Please, review and merge ASAP, as this is a breaking change in some of our workflows.

Thanks!