### PR TITLE
Add timeout as explicit input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,9 @@ inputs:
   atomic:
     description: If true, upgrade process rolls back changes made in case of failed upgrade. Defaults to true.
     required: false
+  timeout:
+    description: Specify a timeout for helm deployment.
+    required: false
   helm:
     description: Helm binary to execute, one of [helm, helm3].
     required: false


### PR DESCRIPTION
- Currently, `timeout` is an input that can be used but using it will produce a warning
- This pull request adds `timeout` as an explicit input, removing the warning